### PR TITLE
Enhancement: Assign Mask Permissions to Specific Backend User Groups

### DIFF
--- a/Configuration/Backend/Modules.php
+++ b/Configuration/Backend/Modules.php
@@ -13,6 +13,8 @@ return [
             \HOV\MaskPermissions\Controller\PermissionController::class => [
                 'index',
                 'update',
+                'selectMasks',
+                'saveMasks',
             ],
         ],
     ],

--- a/Resources/Private/Partials/Form.html
+++ b/Resources/Private/Partials/Form.html
@@ -22,6 +22,7 @@
         <f:be.infobox message="Everything up to date."/>
     </f:else>
 </f:if>
+
 <ul class="list-group">
     <f:for each="{groups}" as="group">
         <li class="list-group-item">
@@ -29,6 +30,8 @@
             <f:if condition="{updatesNeeded.{group.uid}}">
                 <f:then>
                     <f:link.action action="update" arguments="{group: group}" class="btn btn-sm btn-xs btn-primary mp-button">Grant permissions</f:link.action>
+                    <f:link.action action="selectMasks" arguments="{group: group}" class="btn btn-sm btn-xs btn-secondary mp-button">Assign MASK Permissions</f:link.action>
+
                     <span class="badge badge-warning pull-right">Missing permissions</span>
                 </f:then>
                 <f:else>

--- a/Resources/Private/Templates/Permission/SelectMasks.html
+++ b/Resources/Private/Templates/Permission/SelectMasks.html
@@ -1,0 +1,40 @@
+<f:layout name="Module" />
+
+<f:section name="Content">
+  <div class="container my-5">
+    <h1 class="mb-4 fw-semibold text-primary-emphasis">
+      Assign MASK Permissions to <span class="text-decoration-underline">{group.title}</span>
+    </h1>
+
+    <f:form action="saveMasks" controller="Permission">
+      <f:form.hidden name="group" value="{group.uid}" />
+
+      <div class="row row-cols-1 row-cols-md-2 g-4">
+        <f:for each="{maskElements}" as="element" key="key">
+          <div class="col">
+            <div class="card p-2 h-100 d-flex align-items-center justify-content-center">
+              <div class="form-check w-100">
+                <f:form.checkbox 
+                  class="form-check-input me-2"
+                  name="selected[]"
+                  id="checkbox-{key}"
+                  value="{key}"
+                  checked="{f:if(condition: '{key} === {selectedMaskElements.{key}}', then: 'checked')}" />
+                <label 
+                  class="form-check-label fw-bold text-break"
+                  for="checkbox-{key}"
+                  title="{element}">
+                  {element}
+                </label>
+              </div>
+            </div>
+          </div>
+        </f:for>
+      </div>
+
+      <div class="mt-5 text-center">
+        <f:form.submit value="Save Permissions" class="btn btn-primary btn-lg px-5" />
+      </div>
+    </f:form>
+  </div>
+</f:section>


### PR DESCRIPTION
Hello @nhovratov 

### Summary
This PR introduces the ability to assign permissions for **specific Mask elements** to **specific backend user groups**, instead of applying permissions globally to all elements.

### Why This is Needed
In many TYPO3 installations, not all backend user groups require access to all Mask elements. Prior to this change, permissions had to be managed manually through the backend user group module, which is tedious and inefficient—especially in large installations.

With this feature:
- Admins can define which Mask elements are accessible for each backend user group.
- Permission management becomes more granular and maintainable.
- Reduces manual work and risk of misconfiguration.

### Use Case
For example, a **"News Editor"** group may only need access to Mask elements related to news content, while a **"Page Builder"** group should have access to layout or section elements. This feature supports such precise access control out of the box.

### Screenshot for Reference
Here is a screenshot showing the new functionality in action:

![mask](https://github.com/user-attachments/assets/f7b7c866-ffdc-4fd6-a509-00c4a8791a99)
![mask-2](https://github.com/user-attachments/assets/cf317746-1111-4229-848f-b612172b4481)

### Feedback Welcome
Please share your feedback or suggestions—I'd love to improve this further based on your input!
